### PR TITLE
Use vanilla translations if applicable for some basic strings

### DIFF
--- a/src/main/java/io/github/joaoh1/okzoomer/client/config/OkZoomerConfigScreen.java
+++ b/src/main/java/io/github/joaoh1/okzoomer/client/config/OkZoomerConfigScreen.java
@@ -83,9 +83,9 @@ public class OkZoomerConfigScreen {
 			.setDefaultValue(ZoomModes.HOLD)
 			.setNameProvider(value -> {
 				if (value.equals(ZoomModes.HOLD)) {
-					return new TranslatableText("config.okzoomer.zoom_mode.hold");
+					return new TranslatableText("options.key.hold");
 				} else if (value.equals(ZoomModes.TOGGLE)) {
-					return new TranslatableText("config.okzoomer.zoom_mode.toggle");
+					return new TranslatableText("options.key.toggle");
 				} else if (value.equals(ZoomModes.PERSISTENT)) {
 					return new TranslatableText("config.okzoomer.zoom_mode.persistent");
 				}

--- a/src/main/resources/assets/okzoomer/lang/en_us.json
+++ b/src/main/resources/assets/okzoomer/lang/en_us.json
@@ -20,8 +20,6 @@
 	"config.okzoomer.zoom_transition.tooltip.smooth": "\"Smooth\" replicates Vanilla's dynamic FOV.",
 	"config.okzoomer.zoom_transition.tooltip.sine": "\"Sine\" applies the transition with a sine function.",
 	"config.okzoomer.zoom_mode": "Zoom Mode",
-	"config.okzoomer.zoom_mode.hold": "Hold",
-	"config.okzoomer.zoom_mode.toggle": "Toggle",
 	"config.okzoomer.zoom_mode.persistent": "Persistent",
 	"config.okzoomer.zoom_mode.tooltip": "The behavior of the zoom key.",
 	"config.okzoomer.zoom_mode.tooltip.hold": "\"Hold\" needs the zoom key to be hold.",


### PR DESCRIPTION
This PR changes translations to use default vanilla translations for the strings `off`, `hold`, `toggle` and `none`.
It also removes the old strings from already existing translations.

This will:
- Reduce unnecessary translation strings
- Adjust automatically in case vanilla changes something

I didn't feel like creating an issue first to discuss, so feel free to close this if you think it should be done differently.

But consider that other mods utilize vanilla translations too, even ModMenu does this for the Yes/No strings, so OkZoomer should propably do it as well.


