### PR TITLE
Clone details from libs.versions.toml.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,18 +2,18 @@
 org.gradle.jvmargs = -Xmx1G
 
 # Fabric Properties, check these on https://github.com/QuiltMC/quilt-mappings/tags
-minecraft_version = 1.17.1
-mappings_version = 1.17.1+build.17
-loader_version = 0.12.5
+minecraft_version = 1.18.2
+mappings_version = 1.18.2+build.3
+loader_version = 0.13.3
 
 # Mod Properties
-mod_version = 5.0.0-beta.3+1.17.1
+mod_version = 5.0.0-beta.4+1.18.2
 maven_group = io.github.ennuil
 archives_base_name = okzoomer
 
 # Dependencies, check Fabric API's version on https://fabricmc.net/versions.html
-fabric_version = 0.43.1+1.17
-libzoomer_version = 0.3.0+1.17.1
-mod_menu_version = 2.0.14
-spruceui_version = 3.3.0+1.17
+fabric_version = 0.47.9+1.18.2
+libzoomer_version = 0.4.0+1.18.2
+mod_menu_version = 3.1.0
+spruceui_version = 3.3.2+1.17
 json5_version = 1.0.0


### PR DESCRIPTION
This ensures gradle recognizes that we are on 1.18.2 and not the outdated version,
will go ahead and mark this as beta 4 as the mc version is newer.